### PR TITLE
Fix first day of week for China (CLDR-11510)

### DIFF
--- a/common/supplemental/supplementalData.xml
+++ b/common/supplemental/supplementalData.xml
@@ -4677,7 +4677,7 @@ XXX Code for transations where no currency is involved
 			001
 			AD AI AL AM AN AT AX AZ
 			BA BE BG BM BN BY
-			CH CL CM CR CY CZ
+			CH CL CM CN CR CY CZ
 			DE DK
 			EC EE ES
 			FI FJ FO FR
@@ -4701,7 +4701,7 @@ XXX Code for transations where no currency is involved
           <firstDay day="sun"  territories="
 			AG AR AS AU
 			BD BR BS BT BW BZ
-			CA CN CO
+			CA CO
 			DM DO
 			ET
 			GT GU


### PR DESCRIPTION
The first day of the week in China (Mainland) should be Monday according to the national standard GB/T 7408-2005.

<!--
Thank you for your pull request.
Please see http://cldr.unicode.org/index/process for general
information on contributing to CLDR.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-11510
- [x] Updated PR title and link in previous line to include Issue number

